### PR TITLE
Added install of selenium-webdriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ git clone https://github.com/ncalexan/browsertime ncalexan-browsertime
 cd ncalexan-browsertime
 git checkout master
 # Or at least c0813a288dda892c0125ee53855d00eae4fa469a.
+```
+
+Install the base `selenium-webdriver` and then the packages from this repository:
+```
+npm install selenium-webdriver
 npm install
 ```
 


### PR DESCRIPTION
Bumped into the error below if I ran `npm install` on the repo without first installing `selenium-webdriver`

```
npm ERR! path /Users/acreskey/dev/git/browsertime/node_modules/.staging/selenium-webdriver-785c90c7/node_modules/accepts
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall rename
npm ERR! enoent ENOENT: no such file or directory, rename '/Users/acreskey/dev/git/browsertime/node_modules/.staging/selenium-webdriver-785c90c7/node_modules/accepts' -> '/Users/acreskey/dev/git/browsertime/node_modules/.staging/accepts-3a5b3a08'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent
```